### PR TITLE
Support label feature

### DIFF
--- a/lib/fluent/plugin/out_add.rb
+++ b/lib/fluent/plugin/out_add.rb
@@ -1,6 +1,11 @@
 class Fluent::AddOutput < Fluent::Output
   Fluent::Plugin.register_output('add', self)
 
+   # Define `router` method of v0.12 to support v0.10.57 or earlier
+  unless method_defined?(:router)
+    define_method("router") { Fluent::Engine }
+  end
+
   config_param :add_tag_prefix, :string, :default => 'greped'
 
   def initialize

--- a/lib/fluent/plugin/out_add.rb
+++ b/lib/fluent/plugin/out_add.rb
@@ -35,7 +35,7 @@ class Fluent::AddOutput < Fluent::Output
       @add_hash.each do |k,v|
         record[k] = v
       end
-      Fluent::Engine.emit(emit_tag, time, record)
+      router.emit(emit_tag, time, record)
     end
 
     chain.next


### PR DESCRIPTION
Fluentd v0.12 supports label feature.
This feature is enabled by using `router.emit` instead of `Engine.emit`.
And I added keeping backward compatibility hack.