### PR TITLE
Use test-unit gem explicitly

### DIFF
--- a/fluent-plugin-add.gemspec
+++ b/fluent-plugin-add.gemspec
@@ -20,5 +20,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
+  spec.add_development_dependency "test-unit", "~> 3.1.0"
   spec.add_runtime_dependency "fluentd"
 end


### PR DESCRIPTION
Because Ruby 2.2 does not provide minitest with test-unit compatible layer.