### PR TITLE
Add filter plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 ## Configration
 
+### AddOutput
+
     <match test.**>
       type add
       add_tag_prefix debug
@@ -23,6 +25,21 @@
 ### then output bocomes as belows
     debug.test.aa: {"json":"dayo", "hoge":"moge","hogehoge":"mogemoge"}
 
+### AddFilter
+
+    <filter test.**>
+      type add
+      <pair>
+        hoge moge
+        hogehoge mogemoge
+      </pair>
+    </filter>
+
+
+### Assuming following inputs are coming:
+    test.aa: {"json":"dayo"}
+### then output bocomes as belows
+    debug.test.aa: {"json":"dayo", "hoge":"moge","hogehoge":"mogemoge"}
 
 ## Contributing
 

--- a/lib/fluent/plugin/filter_add.rb
+++ b/lib/fluent/plugin/filter_add.rb
@@ -1,0 +1,28 @@
+class Fluent::AddFilter < Fluent::Filter
+  Fluent::Plugin.register_filter('add', self)
+
+  def initialize
+    super
+  end
+
+  def configure(conf)
+    super
+
+    @add_hash = Hash.new
+
+    conf.elements.select {|element|
+      element.name == 'pair'
+    }.each do |pair|
+      pair.each do | k,v|
+       @add_hash[k] = v
+      end
+    end
+  end
+
+  def filter(tag, time, record)
+    @add_hash.each do |k,v|
+      record[k] = v
+    end
+    record
+  end
+end

--- a/lib/fluent/plugin/filter_add.rb
+++ b/lib/fluent/plugin/filter_add.rb
@@ -25,4 +25,4 @@ class Fluent::AddFilter < Fluent::Filter
     end
     record
   end
-end
+end if defined?(Fluent::Filter)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -23,6 +23,7 @@ unless ENV.has_key?('VERBOSE')
 end
 
 require 'fluent/plugin/out_add'
+require 'fluent/plugin/filter_add'
 
 class Test::Unit::TestCase
 end

--- a/test/plugin/test_filter_add.rb
+++ b/test/plugin/test_filter_add.rb
@@ -25,7 +25,7 @@ class AddFilterTest < Test::Unit::TestCase
 
     time = Time.parse("2011-01-02 13:14:15 UTC").to_i
     d.run do
-      d.emit("a" => 1)
+      d.filter("a" => 1)
     end
     mapped = {'hoge' => 'moge', 'hogehoge' => 'mogemoge'}
     expect = {"a" => 1}.merge(mapped)

--- a/test/plugin/test_filter_add.rb
+++ b/test/plugin/test_filter_add.rb
@@ -2,6 +2,8 @@ require 'helper'
 
 class AddFilterTest < Test::Unit::TestCase
   def setup
+    omit("Use Fluentd v0.12 or later.") unless defined?(Fluent::Filter)
+
     Fluent::Test.setup
   end
 

--- a/test/plugin/test_filter_add.rb
+++ b/test/plugin/test_filter_add.rb
@@ -1,0 +1,34 @@
+require 'helper'
+
+class AddFilterTest < Test::Unit::TestCase
+  def setup
+    Fluent::Test.setup
+  end
+
+  CONFIG = %[
+    <pair>
+      hoge moge
+      hogehoge mogemoge
+    </pair>
+  ]
+
+  def create_driver(conf = CONFIG, tag='test')
+    Fluent::Test::FilterTestDriver.new(Fluent::AddFilter, tag).configure(conf)
+  end
+
+  def test_configure
+    d = create_driver
+  end
+
+  def test_format
+    d = create_driver
+
+    time = Time.parse("2011-01-02 13:14:15 UTC").to_i
+    d.run do
+      d.emit("a" => 1)
+    end
+    mapped = {'hoge' => 'moge', 'hogehoge' => 'mogemoge'}
+    expect = {"a" => 1}.merge(mapped)
+    assert_equal expect, d.filtered_as_array[0][2]
+  end
+end


### PR DESCRIPTION
Thanks for providing the simple modification records plugin!

This plugin is one of the suitable case for filter plugin because this plugin is only modifying records.

In more detail, please refer to the official document: http://docs.fluentd.org/articles/filter-plugin-overview or, sonots' Qiita article: http://qiita.com/sonots/items/25a354b5e8aa524faeef.

Please consider that providing filter version of fluent-plugin-add.

Cheers!