### PR TITLE
Fix warnings about "unused configuration" in filter_add.rb

### DIFF
--- a/lib/fluent/plugin/filter_add.rb
+++ b/lib/fluent/plugin/filter_add.rb
@@ -17,6 +17,7 @@ class Fluent::AddFilter < Fluent::Filter
       element.name == 'pair'
     }.each do |pair|
       pair.each do | k,v|
+       pair.has_key?(k)  # suppress warnings about unused configuration
        @add_hash[k] = v
       end
     end


### PR DESCRIPTION
## Issue

When fluentd starts up, it emits the following warnings about the `<pair>` tag, even though the plugin works just as expected:

```
2016-04-27 15:36:38 -0700 [warn]: fluent/engine.rb:112:block in run_configure: section <pair> is not used in <filter app.** service.** system.**> of add plugin
2016-04-27 15:36:38 -0700 [warn]: fluent/engine.rb:112:block in run_configure: section <pair> is not used in <filter app.** service.** system.**> of add plugin
2016-04-27 15:36:38 -0700 [warn]: fluent/engine.rb:112:block in run_configure: section <pair> is not used in <filter app.** service.** system.**> of add plugin
... <repeats> ...
```

I stole this solution from record_reformer: https://github.com/sonots/fluent-plugin-record-reformer/blob/master/lib/fluent/plugin/out_record_reformer.rb#L51-L55