### PR TITLE
Migrate to v0.14 API

### DIFF
--- a/fluent-plugin-add.gemspec
+++ b/fluent-plugin-add.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "test-unit", "~> 3.1.0"
-  spec.add_runtime_dependency "fluentd"
+  spec.add_runtime_dependency "fluentd", [">= 0.14.8", "< 2"]
 end

--- a/lib/fluent/plugin/filter_add.rb
+++ b/lib/fluent/plugin/filter_add.rb
@@ -4,8 +4,8 @@ require 'fluent/plugin/filter'
 class Fluent::Plugin::AddFilter < Fluent::Plugin::Filter
   Fluent::Plugin.register_filter('add', self)
 
-  config_param :uuid, :bool, :default => false
-  config_param :uuid_key, :string, :default => 'uuid'
+  config_param :uuid, :bool, default: false
+  config_param :uuid_key, :string, default: 'uuid'
 
   def initialize
     super

--- a/lib/fluent/plugin/filter_add.rb
+++ b/lib/fluent/plugin/filter_add.rb
@@ -1,6 +1,7 @@
 require 'securerandom'
+require 'fluent/plugin/filter'
 
-class Fluent::AddFilter < Fluent::Filter
+class Fluent::Plugin::AddFilter < Fluent::Plugin::Filter
   Fluent::Plugin.register_filter('add', self)
 
   config_param :uuid, :bool, :default => false
@@ -34,4 +35,4 @@ class Fluent::AddFilter < Fluent::Filter
     end
     record
   end
-end if defined?(Fluent::Filter)
+end

--- a/lib/fluent/plugin/out_add.rb
+++ b/lib/fluent/plugin/out_add.rb
@@ -6,9 +6,9 @@ class Fluent::Plugin::AddOutput < Fluent::Plugin::Output
 
   helpers :event_emitter
 
-  config_param :add_tag_prefix, :string, :default => 'greped'
-  config_param :uuid, :bool, :default => false
-  config_param :uuid_key, :string, :default => 'uuid'
+  config_param :add_tag_prefix, :string, default: 'greped'
+  config_param :uuid, :bool, default: false
+  config_param :uuid_key, :string, default: 'uuid'
 
   def initialize
     super

--- a/lib/fluent/plugin/out_add.rb
+++ b/lib/fluent/plugin/out_add.rb
@@ -6,11 +6,6 @@ class Fluent::Plugin::AddOutput < Fluent::Plugin::Output
 
   helpers :event_emitter
 
-   # Define `router` method of v0.12 to support v0.10.57 or earlier
-  unless method_defined?(:router)
-    define_method("router") { Fluent::Engine }
-  end
-
   config_param :add_tag_prefix, :string, :default => 'greped'
   config_param :uuid, :bool, :default => false
   config_param :uuid_key, :string, :default => 'uuid'

--- a/lib/fluent/plugin/out_add.rb
+++ b/lib/fluent/plugin/out_add.rb
@@ -1,7 +1,10 @@
 require 'securerandom'
+require 'fluent/plugin/output'
 
-class Fluent::AddOutput < Fluent::Output
+class Fluent::Plugin::AddOutput < Fluent::Plugin::Output
   Fluent::Plugin.register_output('add', self)
+
+  helpers :event_emitter
 
    # Define `router` method of v0.12 to support v0.10.57 or earlier
   unless method_defined?(:router)
@@ -29,16 +32,16 @@ class Fluent::AddOutput < Fluent::Output
         Proc.new {|tag| tag }
       end
     conf.elements.select {|element|
-      element.name == 'pair' 
+      element.name == 'pair'
     }.each do |pair|
       pair.each do | k,v|
        pair.has_key?(k) # suppress warnings about unused configuration
        @add_hash[k] = v
       end
-    end 
+    end
   end
 
-  def emit(tag, es, chain)
+  def process(tag, es)
     emit_tag = @tag_proc.call(tag)
 
     es.each do |time,record|
@@ -50,8 +53,6 @@ class Fluent::AddOutput < Fluent::Output
       end
       router.emit(emit_tag, time, record)
     end
-
-    chain.next
   end
 
 end

--- a/lib/fluent/plugin/out_add.rb
+++ b/lib/fluent/plugin/out_add.rb
@@ -6,7 +6,8 @@ class Fluent::Plugin::AddOutput < Fluent::Plugin::Output
 
   helpers :event_emitter
 
-  config_param :add_tag_prefix, :string, default: 'greped'
+  config_param :add_tag_prefix, :string, default: 'greped',
+               deprecated: "use @label instead for event routing"
   config_param :uuid, :bool, default: false
   config_param :uuid_key, :string, default: 'uuid'
 

--- a/test/plugin/test_filter_add.rb
+++ b/test/plugin/test_filter_add.rb
@@ -1,9 +1,8 @@
 require 'helper'
+require 'fluent/test/driver/filter'
 
 class AddFilterTest < Test::Unit::TestCase
   def setup
-    omit("Use Fluentd v0.12 or later.") unless defined?(Fluent::Filter)
-
     Fluent::Test.setup
   end
 
@@ -21,8 +20,8 @@ class AddFilterTest < Test::Unit::TestCase
     </pair>
   ]
 
-  def create_driver(conf = CONFIG, tag='test')
-    Fluent::Test::FilterTestDriver.new(Fluent::AddFilter, tag).configure(conf)
+  def create_driver(conf = CONFIG)
+    Fluent::Test::Driver::Filter.new(Fluent::Plugin::AddFilter).configure(conf)
   end
 
   def test_configure
@@ -34,31 +33,27 @@ class AddFilterTest < Test::Unit::TestCase
     d = create_driver
 
     time = Time.parse("2011-01-02 13:14:15 UTC").to_i
-    d.run do
-      d.filter("a" => 1)
+    d.run(default_tag: 'test') do
+      d.feed(time, "a" => 1)
     end
     mapped = {'hoge' => 'moge', 'hogehoge' => 'mogemoge'}
     expect = {"a" => 1}.merge(mapped)
-    assert_equal expect, d.filtered_as_array[0][2]
+    assert_equal [expect], d.filtered.map {|e| e.last }
   end
   def test_uu
     d = create_driver(CONFIG_UU)
 
-    d.run do
-      d.emit("a" => 1)
+    d.run(default_tag: 'test') do
+      d.feed("a" => 1)
     end
-    assert d.filtered_as_array[0][2].has_key?('uuid')
-
-    d.run
+    assert d.filtered.map {|e| e.last }.first.has_key?('uuid')
   end
   def test_uuid_key
     d = create_driver("#{CONFIG_UU}\nuuid_key test_uuid")
 
-    d.run do
-      d.emit("a" => 1)
+    d.run(default_tag: 'test') do
+      d.feed("a" => 1)
     end
-    assert d.filtered_as_array[0][2].has_key?('test_uuid')
-
-    d.run
+    assert d.filtered.map {|e| e.last }.first.has_key?('test_uuid')
   end
 end


### PR DESCRIPTION
I've migrated this plugin to use v0.14 API.
**Notice:** This PR contains BRAKING CHANGES.

Even if this PR is acceptable, please don't merge immediately.

First, we should release dependency Fluentd version locked version to ensure lock dependency for Fluentd v0.12.
And then, please merge this PR.
Finally, we should bump up dependent Fluentd version to 0.14.4 or later, bump up major version, and publish to rubygems.

And Fluentd upstream developer says that "don't manipulation tag in output plugin, use labels. If a plugin can implement same feature in output and filter plugin, we recommend to use filter and abandon output plugin." See: https://github.com/y-ken/fluent-plugin-anonymizer/pull/18#issuecomment-244884172

But I think that this output plugin does not implement complex tag manipulating, it is reasonable to provide both of output and filter versions.

What do you think about this? Should we announce to recommend to use filter version and abandon output version?
