### PR TITLE
travis: Add Ruby 2.4.0 task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: ruby
 rvm:
+- 2.4.0
 - 2.3.0
 - 2.2
 - 2.1


### PR DESCRIPTION
td-agent3 will ship with Ruby 2.4. 
So, let's confirm CI passing with Ruby 2.4.0. :shark: